### PR TITLE
refactor: consolidate drag handling and remove redundant styles

### DIFF
--- a/src/features/auth/SignIn.module.css
+++ b/src/features/auth/SignIn.module.css
@@ -107,14 +107,4 @@
     block-size: 100%;
     object-fit: cover;
   }
-
-  .folderDraggable {
-    inline-size: 100%;
-    block-size: 40px;
-    background-color: transparent;
-    border-radius: .625rem .625rem 0 0;
-    position: absolute;
-    top: 0;
-    left: 0;
-  }
 }

--- a/src/features/auth/SignIn.tsx
+++ b/src/features/auth/SignIn.tsx
@@ -42,7 +42,7 @@ export default function SignIn({ containerRef }: SignInProps) {
 				className={styles.image}
 				draggable={false}
 			/>
-			<Window.Header className={styles.folderDraggable} />
+			<Window.DragArea />
 		</Window>
 	);
 }

--- a/src/features/folder/Folder.module.css
+++ b/src/features/folder/Folder.module.css
@@ -9,17 +9,6 @@
   border: 1px var(--color-grey--100) solid;
   box-shadow: rgba(25, 21, 33, 0.05) 2px 4px 15px, rgba(25, 21, 33, .2) 0px 5px 9px -3px;
 
-  .folderDraggable {
-    /* grid-area: header; */
-    background-color: transparent;
-    border-radius: .625rem .625rem 0 0;
-    position: absolute;
-    inline-size: 100%;
-    block-size: 40px;
-    top: 0;
-    left: 0;
-  }
-
   .sidebar {
     grid-area: sidebar;
     background-color: var(--color-white--100-transparent-low);

--- a/src/features/folder/Folder.tsx
+++ b/src/features/folder/Folder.tsx
@@ -138,7 +138,7 @@ export default function Folder({ containerRef }: FolderProps) {
 				</Contextmenu>
 			</section>
 
-			<Window.Header className={styles.folderDraggable} />
+			<Window.DragArea />
 		</Window>
 	);
 }

--- a/src/features/music/MusicPlayer.module.css
+++ b/src/features/music/MusicPlayer.module.css
@@ -224,14 +224,4 @@
     }
 
   }
-
-  .MusicPlayerHeader {
-    background-color: transparent;
-    border-radius: .625rem .625rem 0 0;
-    position: absolute;
-    inline-size: 100%;
-    block-size: 40px;
-    top: 0;
-    left: 0;
-  }
 }

--- a/src/features/music/MusicPlayer.tsx
+++ b/src/features/music/MusicPlayer.tsx
@@ -179,13 +179,13 @@ export default function MusicPlayer({ containerRef }: MusicPlayerProps) {
 					}}
 				/>
 			</section>
-			<Window.Header className={styles.MusicPlayerHeader}>
+			<Window.DragArea>
 				<CassetteTape
 					isPlaying={isPlaying}
 					progress={(progress * 100) / duration}
 					image={currentSong?.imageURL}
 				/>
-			</Window.Header>
+			</Window.DragArea>
 		</Window>
 	);
 }

--- a/src/features/window/Window.module.css
+++ b/src/features/window/Window.module.css
@@ -1,4 +1,4 @@
-.header{
+.window{
   position: relative;
   .actions{
     position: absolute;
@@ -29,5 +29,14 @@
       }
     }
 
+  }
+  .dragArea{
+    background-color: transparent;
+    border-radius: .625rem .625rem 0 0;
+    position: absolute;
+    inline-size: 100%;
+    block-size: 40px;
+    top: 0;
+    left: 0;
   }
 }

--- a/src/features/window/Window.tsx
+++ b/src/features/window/Window.tsx
@@ -123,52 +123,51 @@ function Window({ id, children, className, containerRef }: WindowProps) {
 		dispatch(bringToFront({ id }));
 	}
 
+	function handleButtonMouseDown(e: React.MouseEvent<Element, MouseEvent>) {
+		e.stopPropagation();
+		dispatch(closeWindowAsync({ id }));
+	}
+
 	return (
 		<WindowContext.Provider value={{ handleMouseDown, id }}>
 			<article
-				className={className}
+				className={`${styles.window} ${className}`}
 				ref={dragRef}
 				onMouseDown={handleBringToFront}
 				style={{ position: 'absolute' }}
 			>
+				<ul className={styles.actions}>
+					<li>
+						<button
+							className={styles.cross}
+							onMouseDown={handleButtonMouseDown}
+						>
+							x
+						</button>
+					</li>
+				</ul>
 				{children}
 			</article>
 		</WindowContext.Provider>
 	);
 }
 
-type HeaderProps = PropsWithChildren<{
+type DragAreaProps = PropsWithChildren<{
 	className?: string;
 }>;
-function Header({ children, className }: HeaderProps) {
-	const { handleMouseDown, id } = useWindow();
-	const dispatch = useAppDispatch();
-	const handleButtonMouseDown = (e: React.MouseEvent<Element, MouseEvent>) => {
-		e.stopPropagation();
-		dispatch(closeWindowAsync({ id }));
-	};
+
+function DragArea({ children, className }: DragAreaProps) {
+	const { handleMouseDown } = useWindow();
 	return (
-		<header
-			className={`${styles.header} ${className}`}
+		<section
+			className={`${styles.dragArea} ${className}`}
 			onMouseDown={handleMouseDown}
 		>
-			<ul className={styles.actions}>
-				<li>
-					<button className={styles.cross} onMouseDown={handleButtonMouseDown}>
-						x
-					</button>
-				</li>
-			</ul>
 			{children}
-		</header>
+		</section>
 	);
 }
 
-function Body({ children }: PropsWithChildren) {
-	return <section>{children}</section>;
-}
-
-Window.Header = Header;
-Window.Body = Body;
+Window.DragArea = DragArea;
 
 export default Window;


### PR DESCRIPTION
- Moved `handleButtonMouseDown` into the main `Window` component to reduce repetition.
- Removed the `Header` component, replacing it with a `DragArea` section to simplify structure.